### PR TITLE
On 69 database script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "start": "set PORT=3000 && react-scripts start",
     "build": "react-scripts build",
     "test": "jest --testTimeout=10000 --detectOpenHandles",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "dbscript": "node ./server/testhelper/initializedatabase",
+    "initdb": "yarn dbscript"
   },
   "eslintConfig": {
     "extends": [

--- a/server/testhelper/initializedatabase.js
+++ b/server/testhelper/initializedatabase.js
@@ -2,10 +2,12 @@ const {testUser, testUser1, testUserBusId} = require('./variables');
 const request = require('supertest');
 const app = require('../server');
 const mongoose = require('mongoose');
-//const disconnectDB = require('../config/db');
+
+
 if(process.env.npm_lifecycle_event === 'dbscript'){
     start();
 }
+
 
 async function start(){
     await initializeDatabase();
@@ -32,7 +34,7 @@ async function start(){
 
 async function initializeDatabase(){
     try{
-        /*const user1 = await request(app)
+        const user1 = await request(app)
             .post('/user/register')
             .expect(201)
             .send(testUser);
@@ -45,7 +47,7 @@ async function initializeDatabase(){
         const user3 = await request(app)
             .post('/user/register')
             .expect(201)
-            .send(testUserBusId);*/
+            .send(testUserBusId);
     }
     catch(e){
         return {err: 'Error creating users'};

--- a/server/testhelper/initializedatabase.js
+++ b/server/testhelper/initializedatabase.js
@@ -1,37 +1,133 @@
-const {testUser, testUser1, testUserBusId} = require('./variables');
+const {testUser, testUser1, testUserBusId, testBusiness, testTill, testTab, testCard, testItem} = require('./variables');
 const request = require('supertest');
 const app = require('../server');
 const mongoose = require('mongoose');
+const { exit } = require('process');
 
 
+/**
+ * If the script run is the 'yarn initdb' script, initialize the database
+ */
 if(process.env.npm_lifecycle_event === 'dbscript'){
-    start();
+    startDBInitialization();
 }
 
 
-async function start(){
-    await initializeDatabase();
-     try{
-         await mongoose.disconnect();
-         console.log('Disconnecting from database...');
-        if(mongoose.connection.readyState === 0){
-            console.log("Database connection successfully closed.");
-        }
-        else {
-            console.log('Error closing database connection, closing process...');
-            process.exit(1); 
-        }
-        
-        console.log('Exiting process...');
-        process.exit(0);
-    }
-    catch(err){
-        console.error(err);
-        process.exit(1);
-    }
+/**
+ * Starts initialization of populating database
+ *
+ * @success Creates data, closes connection, & ends process
+ * @error 401 Unauthorized, Invalid Token
+ *        404 Not Found, User has no business
+ *        403 Forbidden, User does not exist
+ *        500 Internal Server Error
+ */
+async function startDBInitialization(){
+    await initializeDatabaseNewScript();
+    await closeConnections();
 }
 
 
+/**
+ * Creates data in connected database
+ *
+ * @success Creates data
+ * @error 401 Unauthorized, Invalid Token
+ *        404 Not Found, User has no business
+ *        403 Forbidden, User does not exist
+ *        500 Internal Server Error
+ */
+async function initializeDatabaseNewScript(){
+    console.log('Creating data:')
+    const user1 = await request(app)
+        .post('/user/register')
+        //.expect(201)
+        .send(testUser);
+    if(user1._body.err != null){
+        console.log(`\tError creating User: ${user1._body.err}.`);
+        console.log('\tStopping data creation...');
+        return;
+    }
+
+    const loginUser1 = await request(app)
+        .post('/user/login')
+        //.expect(200)
+        .send({email: testUser.email, password: testUser.password});
+    if(loginUser1._body.err != null){
+        console.log(`\tError logging in User: ${loginUser1._body.err}.`);
+        console.log('\tStopping data creation...');
+        return;
+    }
+
+    const businessUser1 = await request(app)
+        .post('/business/create')
+        .set('authorization', loginUser1.body.token) 
+        //.expect(201)
+        .send(testBusiness);
+    if(businessUser1._body.err != null){
+        console.log(`\tError creating Business: ${businessUser1._body.err}.`);
+        console.log('\tStopping data creation...');
+        return;
+    }
+
+    testTill.businessId = businessUser1._body.formattedBus.id;
+    const tillUser1 = await request(app)
+        .post('/till/create')
+        .set('authorization', loginUser1.body.token) 
+        //.expect(201)
+        .send(testTill);
+    if(tillUser1._body.err != null){
+        console.log(`\tError creating Till: ${tillUser1._body.err}.`);
+        console.log('\tStopping data creation...');
+        return;
+    }
+
+    testTab.tillId = tillUser1._body.formattedTill.id;
+    const tabUser1 = await request(app)
+        .post('/tab/create')
+        .set('authorization', loginUser1.body.token) 
+        //.expect(201)
+        .send(testTab);
+    if(tabUser1._body.err != null){
+        console.log(`\tError creating Tab: ${tabUser1._body.err}.`);
+        console.log('\tStopping data creation...');
+        return;
+    }
+
+    testCard.tabId = tabUser1._body.formattedTab.id;
+    const cardUser1 = await request(app)
+        .post('/card/create')
+        .set('authorization', loginUser1.body.token) 
+        //.expect(201)
+        .send(testCard);
+    if(cardUser1._body.err != null){
+        console.log(`\tError creating Card: ${cardUser1._body.err}.`);
+        console.log('\tStopping data creation...');
+        return;
+    }
+
+    testItem.cardId = cardUser1._body.formattedCard.id;
+    const itemUser1 = await request(app)
+        .post('/items/create')
+        .set('authorization', loginUser1.body.token) 
+        //.expect(201)
+        .send(testItem);
+    if(itemUser1._body.err != null){
+        console.log(`\tError creating Item: ${itemUser1._body.err}.`);
+        console.log('\tStopping data creation...');
+        return;
+    }
+    console.log('\tData created successfully.');
+}
+
+
+/**
+ * TODO: remove this functionality in ON-122 to use new script
+ * Initializes database for running unit tests
+ *
+ * @success Creates data
+ * @error Error creating users
+ */
 async function initializeDatabase(){
     try{
         const user1 = await request(app)
@@ -51,6 +147,34 @@ async function initializeDatabase(){
     }
     catch(e){
         return {err: 'Error creating users'};
+    }
+}
+
+
+/**
+ * Closes the connection to the database and ends the process
+ *
+ * @success Disconnects from database and ends process
+ * @error Error closing the database
+ */
+async function closeConnections(){
+    try{
+        await mongoose.disconnect();
+        console.log('Disconnecting from database...');
+        if(mongoose.connection.readyState === 0){
+            console.log("\tDatabase connection successfully closed.");
+        }
+        else {
+            console.log('\tError closing database connection, closing process...');
+            process.exit(1); 
+        }
+        
+        console.log('\tExiting process...');
+        process.exit(0);
+    }
+    catch(err){
+        console.error(err);
+        process.exit(1);
     }
 }
 

--- a/server/testhelper/initializedatabase.js
+++ b/server/testhelper/initializedatabase.js
@@ -1,10 +1,38 @@
 const {testUser, testUser1, testUserBusId} = require('./variables');
 const request = require('supertest');
 const app = require('../server');
+const mongoose = require('mongoose');
+//const disconnectDB = require('../config/db');
+if(process.env.npm_lifecycle_event === 'dbscript'){
+    start();
+}
+
+async function start(){
+    await initializeDatabase();
+     try{
+         await mongoose.disconnect();
+         console.log('Disconnecting from database...');
+        if(mongoose.connection.readyState === 0){
+            console.log("Database connection successfully closed.");
+        }
+        else {
+            console.log('Error closing database connection, closing process...');
+            process.exit(1); 
+        }
+        
+        console.log('Exiting process...');
+        process.exit(0);
+    }
+    catch(err){
+        console.error(err);
+        process.exit(1);
+    }
+}
+
 
 async function initializeDatabase(){
     try{
-        const user1 = await request(app)
+        /*const user1 = await request(app)
             .post('/user/register')
             .expect(201)
             .send(testUser);
@@ -17,10 +45,11 @@ async function initializeDatabase(){
         const user3 = await request(app)
             .post('/user/register')
             .expect(201)
-            .send(testUserBusId);
+            .send(testUserBusId);*/
     }
     catch(e){
         return {err: 'Error creating users'};
     }
 }
+
 module.exports = initializeDatabase;

--- a/server/testhelper/variables.js
+++ b/server/testhelper/variables.js
@@ -1,8 +1,8 @@
 let testUser = {
     fname: 'Test',
     lname: 'User',
-    email: 'run_test@gmail.com',
-    password: 'peanut_butter_baby',
+    email: 'test@gmail.com',
+    password: '123',
     businessId: null
 };
 
@@ -10,7 +10,7 @@ let testUser1 = {
     fname: 'Test',
     lname: 'User',
     email: 'run_test1@gmail.com',
-    password: 'peanut_butter_baby',
+    password: '123',
     businessId: null
 };
 
@@ -18,19 +18,19 @@ let testUserBusId = {
     fname: 'Test',
     lname: 'User',
     email: 'run_test3@gmail.com',
-    password: 'peanut_butter_baby',
+    password: '123',
     businessId: '63d2b33a2a75670dbd74fb3b'
 };
 
 let testBusiness = {
-    name: 'Walmart',
+    name: 'Test Business 1',
     type: 'Wholesale',
     admins: [],
     tills: []
 };
 
 let testTill = {
-    name: 'Sandwiches',
+    name: 'Test Location 1',
     managerPassword: 123,
     employees: [],
     tabs: [],


### PR DESCRIPTION
### Description:
This PR implements a new yarn script that will populate the database with some "barebones" data. This script should be able to be run in any database we have, but it does not run when executing unit tests (I have created a [ticket](https://sd-onlinepos.atlassian.net/browse/ON-122) to do this in the future). The specifics of the data can be viewed in `/server/testhelper/initializedatabase.js` and `/server/testhelper/variables.js`.

### Running:
The script is run in the terminal via:
`yarn initdb`

### Note:
If the data is already created in the database, the script will output to the console which model it failed on and stop executing. This is due to the fact our data is one massive chain so if creating a business fails, we must not create tills, tabs, cards, or items. Additionally, if time permits, I would like to expand this to create more data including our users to make it more "dynamic", but it works how it is and creates some data we can work with.